### PR TITLE
refactor: unified setup and run server functions

### DIFF
--- a/bootstrap/server.go
+++ b/bootstrap/server.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func SetupServer(fn func(router *core.Application)) {
+func setupServer(fn func(router *core.Application)) {
 	core.SetupLog()
 
 	e := echo.New()
@@ -58,7 +58,9 @@ func defaultMiddleware(app *echo.Echo) {
 	}
 }
 
-func RunServer() {
+func RunServer(fn func(router *core.Application)) {
+	setupServer(fn)
+
 	if core.GetConfig().Bool("APP.PROFILE") {
 		runtime.SetBlockProfileRate(1)
 		go func() {


### PR DESCRIPTION
```go
bootstrap.SetupServer(routes.Register)
bootstrap.RunServer()
```
를 굳이 두번에 걸쳐할 필요가 있을까?

```go
bootstrap.RunServer(routes.Register)
```
로 한번에 서버셋팅과 시작을 하는 것이 어떨까?